### PR TITLE
Proposed 0.2.0 with major changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 venv
+__pycache__/
+build/
+dist/
+*.egg-info
+*.py[cod]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 Stig Otnes Kolstad
+Copyright (c) 2019-2020 Stig Otnes Kolstad
+Copyright (c) 2020 Aaron D. Marasco
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,44 @@
-.PHONY: build clean upload-test
+.PHONY: build clean help install uninstall test upload-test wheel_check
+.SILENT: help install uninstall test wheel_check
 
-build: clean
+define HELP
+
+Targets:
+
+  - build      - builds the 'wheel' distribution file (calls clean)
+  - clean      - cleans temporary files
+  - install    - builds and locally installs to your interpreter (calls uninstall and build)
+  - uninstall  - removes locally installed copy
+  - test       - runs unit tests
+
+endef
+
+export HELP
+help:
+	echo "$${HELP}"
+	false
+
+build: wheel_check clean
 	python3 setup.py sdist bdist_wheel
 
 clean:
 	rm -rf build dist *.egg-info __pycache__
 
+install: build uninstall
+	pip3 install --user ./dist/sd_notify-*.whl
+
+uninstall:
+	-pip3 uninstall -y sd_notify
+
+test:
+	./test_sd_notify.py
+
 upload-test:
 	python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+WHEEL_INSTALLED = $(shell pip3 list | egrep '^wheel\s')
+wheel_check:
+ifeq ($(WHEEL_INSTALLED),)
+  $(error Need to 'pip3 install wheel')
+endif
+	true

--- a/example/README
+++ b/example/README
@@ -1,0 +1,20 @@
+This is an example showing how to use daemon.py to experiment with sd_notify
+
+To install:
+systemctl --user link $(pwd)/sd-notify-example.service
+systemctl --user daemon-reload  # any time you modify sd-notify-example.service or restart StartLimit timers
+
+To start:
+systemctl --user start sd-notify-example.service
+
+To check / view logs:
+systemctl --user status sd-notify-example.service
+journalctl --user -eu sd-notify-example
+
+To stop:
+systemctl --user stop sd-notify-example.service
+
+Things to try:
+ - Play with daemon.py!
+ - Change the service file and remove the watchdog requirements or change the timeout
+ - Uncomment the notify_error() call

--- a/example/daemon.py
+++ b/example/daemon.py
@@ -1,0 +1,40 @@
+#!/bin/env python3
+import sd_notify
+import time
+
+notify = sd_notify.Notifier()
+
+if not notify.enabled():
+    # Then it's probably not running is systemd with watchdog enabled
+    raise Exception("Watchdog not enabled")
+
+# Report a status message
+notify.status("Starting my service...")
+time.sleep(1)
+
+# Report that the program init is complete - "systemctl start" won't return until ready() called
+notify.ready()
+notify.notify()
+
+timeout_half_sec = int(float(notify.timeout) / 2e6)  # Convert us->s and half that
+notify.status("Waiting {} seconds (1/2)".format(timeout_half_sec))
+time.sleep(timeout_half_sec)
+notify.notify()
+
+notify.status("Waiting {} seconds (2/2)".format(timeout_half_sec))
+time.sleep(timeout_half_sec)
+notify.notify()
+
+count = 0
+while not notify.notify_due:
+    count += 1
+    notify.status("Waiting for notify_due flag: iteration {}".format(count))
+    time.sleep(0.1)  # BUSY LOOPS ARE BAD
+
+# Report an error to the service manager
+# notify.notify_error("Blowing up on purpose!")
+# The service manager will probably kill the program here
+
+notify.status("Simulating hang")
+notify.notify()
+time.sleep(120)

--- a/example/sd-notify-example.service
+++ b/example/sd-notify-example.service
@@ -1,0 +1,15 @@
+# Example sd-notify service file - fix path below
+[Unit]
+Description=sd-notify example service
+StartLimitBurst=5
+StartLimitIntervalSec=600
+
+[Service]
+ExecStart=/home/user/sd-notify/examples/daemon.py
+Restart=on-failure
+RestartSec=10
+Type=notify
+WatchdogSec=15
+
+[Install]
+WantedBy=default.target

--- a/sd_notify.py
+++ b/sd_notify.py
@@ -1,70 +1,109 @@
 """
-Simple sd_notify(3) client functionality implemented in Python 3.
+sd_notify(3) and sd_watchdog_enabled(3) client functionality implemented in Python 3
 
 Usage:
 ```
 import sd_notify
 
 notify = sd_notify.Notifier()
-if not notify.enabled():
+if not notify.is_enabled:
     # Then it's probably not running is systemd with watchdog enabled
         raise Exception("Watchdog not enabled")
 
-    # Report a status message
-    notify.status("Initialising my service...")
-    time.sleep(3)
+# Report a status message
+notify.status("Starting my service...")
+time.sleep(3)
 
-    # Report that the program init is complete
-    notify.ready()
-    notify.status("Waiting for web requests...")
-    time.sleep(3)
+# Report that the program init is complete
+notify.ready()
+notify.status("Waiting for web requests...")
+notify.notify()
+time.sleep(3)
 
-    # Report an error to the service manager
-    notify.notify_error("An irrecoverable error occured!")
-    # The service manager will probably kill the program here
-    time.sleep(3)
+# Compute time between notifications
+timeout_half_sec = int(float(notify.timeout) / 2e6)  # Convert us->s and half that
+time.sleep(timeout_half_sec)
+notify.notify()
+
+# Report an error to the service manager
+notify.notify_error("An irrecoverable error occured!")
+# The service manager will probably kill the program here
+time.sleep(3)
 ```
-
-Author: stig@stigok.com Dec 2019
 """
+from datetime import timedelta, datetime
 import os
 import socket
 
 class Notifier():
-    def __init__(self, *, sock=None, addr=None):
-        self.socket = sock or socket.socket(family=socket.AF_UNIX,
-                                            type=socket.SOCK_DGRAM)
-        self.address = addr or os.getenv("NOTIFY_SOCKET")
+    def __init__(self, sock=None, addr=None):
+        self._socket = sock or socket.socket(family=socket.AF_UNIX,
+                                             type=socket.SOCK_DGRAM)
+        self._address = addr or os.getenv("NOTIFY_SOCKET")
+        self._timeout_td = timedelta(0)
+        self._lastcall = datetime.fromordinal(1)
+
+        # Note this fix is untested in a live system; https://unix.stackexchange.com/q/206386
+        if self._address and self._address[0] == '@':
+            self._address = '\0'+self._address[1:]
+
+        # Check for our timeout
+        if self._address:
+            wtime = os.getenv("WATCHDOG_USEC")
+            wpid = os.getenv("WATCHDOG_PID")
+            if wtime and wtime.isdigit():
+                if wpid is None or (wpid.isdigit() and (wpid == str(os.getpid()))):
+                    self._timeout_td = timedelta(microseconds=int(wtime))
 
     def _send(self, msg):
         """Send string `msg` as bytes on the notification socket"""
-        self.socket.sendto(msg.encode(), self.address)
+        if self.is_enabled:
+            self._socket.sendto(msg.encode(), self._address)
 
     def enabled(self):
         """Return a boolean stating whether watchdog is enabled"""
-        return bool(self.address)
+        return bool(self._address)
 
-    def ready(self):
-        """Report ready service state, i.e. completed initialisation"""
-        self._send("READY=1\n")
-
-    def status(self, msg):
-        """Set a service status message"""
-        self._send("STATUS=%s\n" % (msg,))
+    @property
+    def is_enabled(self):
+        """Property indicating whether watchdog is enabled"""
+        return self.enabled()
 
     def notify(self):
         """Report a healthy service state"""
+        self._lastcall = datetime.now()
         self._send("WATCHDOG=1\n")
+
+    @property
+    def notify_due(self):
+        return (datetime.now() - self._lastcall) >= (self._timeout_td / 2)
 
     def notify_error(self, msg=None):
         """
         Report a watchdog error. This program will likely be killed by the
         service manager.
 
-        If `msg` is not None, it will be reported as an error message to the
-        service manager.
+        If `msg` is provided, it will be reported as a status message prior to the error.
         """
         if msg:
             self.status(msg)
 
         self._send("WATCHDOG=trigger\n")
+
+    def ready(self):
+        """Report ready service state, i.e. completed initialisation"""
+        self._send("READY=1\n")
+
+    @property
+    def timeout(self):
+        """Report the watchdog window in microseconds as int (cf. sd_watchdog_enabled(3) )"""
+        return int(self._timeout_td/timedelta(microseconds=1))
+
+    @property
+    def timeout_td(self):
+        """Report the watchdog window as datetime.timedelta (cf. sd_watchdog_enabled(3) )"""
+        return self._timeout_td
+
+    def status(self, msg):
+        """Set a service status message"""
+        self._send("STATUS=%s\n" % (msg,))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="sd-notify",
-    version="0.1.0",
+    version="0.2.0",
     py_modules=["sd_notify"],
     author="stigok",
     author_email="stig@stigok.com",

--- a/test_sd_notify.py
+++ b/test_sd_notify.py
@@ -1,67 +1,148 @@
+#!/bin/env python3
 import os
+from datetime import timedelta
+from time import sleep
 from unittest import TestCase
-from unittest.mock import Mock, patch, sentinel
+from unittest.mock import Mock, call, patch, sentinel
 
 from sd_notify import Notifier
 
 
 class NotifierTestCase(TestCase):
+    TEST_ADDR = "/var/string/to/socket"
+
     def test_send(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         cut._send("Hello, world!")
-        cut.socket.sendto.assert_called_once_with(b"Hello, world!", sentinel.address)
+        cut._socket.sendto.assert_called_once_with(b"Hello, world!", self.TEST_ADDR)
 
     def test_enabled(self):
+        # We expect these 3 variables to be checked whenever NOTIFY_SOCKET is set:
+        EXPECTED_VARS = [call("NOTIFY_SOCKET"), call("WATCHDOG_USEC"), call("WATCHDOG_PID")]
+
         # With no environment set
         with patch("os.getenv", return_value=None) as getenv_mock:
             cut = Notifier(sock=Mock(spec=["sendto"]))
-            res = cut.enabled()
+            res = cut.enabled() and cut.is_enabled
             getenv_mock.assert_called_once_with("NOTIFY_SOCKET")
             self.assertIs(res, False)
 
         # With empty string set
         with patch("os.getenv", return_value="") as getenv_mock:
             cut = Notifier(sock=Mock(spec=["sendto"]))
-            res = cut.enabled()
+            res = cut.enabled() and cut.is_enabled
             getenv_mock.assert_called_once_with("NOTIFY_SOCKET")
             self.assertIs(res, False)
 
         # With environment set
-        with patch("os.getenv", return_value="a string") as getenv_mock:
+        with patch("os.getenv", return_value=self.TEST_ADDR) as getenv_mock:
             cut = Notifier(sock=Mock(spec=["sendto"]))
-            res = cut.enabled()
-            getenv_mock.assert_called_once_with("NOTIFY_SOCKET")
+            res = cut.enabled() and cut.is_enabled
+            getenv_mock.assert_has_calls(EXPECTED_VARS)
             self.assertIs(res, True)
 
+        # With abstract namespace socket set
+        with patch("os.getenv", return_value="@"+self.TEST_ADDR) as getenv_mock:
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            res = cut.enabled() and cut.is_enabled
+            getenv_mock.assert_has_calls(EXPECTED_VARS)
+            self.assertIs(res, True)
+
+    def test_addr_parsing(self):
+        # Standard address
+        with patch("os.getenv", return_value=self.TEST_ADDR):
+            sock = Mock(spec=["sendto"])
+            cut = Notifier(sock=sock)
+            cut.ready()
+            sock.sendto.assert_called_once_with(b"READY=1\n", self.TEST_ADDR)
+
+        # Abstract namespace address
+        with patch("os.getenv", return_value='@'+self.TEST_ADDR):
+            sock = Mock(spec=["sendto"])
+            cut = Notifier(sock=sock)
+            cut.ready()
+            sock.sendto.assert_called_once_with(b"READY=1\n", '\0'+self.TEST_ADDR)
+
     def test_ready(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         with patch('sd_notify.Notifier._send') as patched_send:
             cut.ready()
             patched_send.assert_called_once_with("READY=1\n")
 
     def test_status(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         with patch('sd_notify.Notifier._send') as patched_send:
             cut.status("Hello, world!")
             patched_send.assert_called_once_with("STATUS=Hello, world!\n")
 
     def test_notify(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         with patch('sd_notify.Notifier._send') as patched_send:
             cut.notify()
             patched_send.assert_called_once_with("WATCHDOG=1\n")
 
     def test_notify_error(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         with patch('sd_notify.Notifier._send') as patched_send:
             # Without msg arg
             cut.notify_error()
             patched_send.assert_called_once_with("WATCHDOG=trigger\n")
 
     def test_notify_error_with_message(self):
-        cut = Notifier(sock=Mock(spec=["sendto"]), addr=sentinel.address)
+        cut = Notifier(sock=Mock(spec=["sendto"]), addr=self.TEST_ADDR)
         with patch('sd_notify.Notifier._send') as patched_send:
             cut.notify_error(msg="Hello world!")
             self.assertEqual(patched_send.call_count, 2)
             patched_send.assert_any_call("WATCHDOG=trigger\n")
             patched_send.assert_any_call("STATUS=Hello world!\n")
+
+    def test_timeout_parsing(self):
+        test_dict = {"NOTIFY_SOCKET": self.TEST_ADDR,
+                     "WATCHDOG_USEC": "15000000",  # 15s
+                    }
+        # simplest, good case (no PID at all)
+        with patch.dict(os.environ, test_dict, clear=True):
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            self.assertEqual(cut.timeout, 15000000)
+
+        # with our PID
+        with patch.dict(os.environ, {"WATCHDOG_PID": str(os.getpid()), **test_dict}, clear=True):
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            self.assertEqual(cut.timeout, 15000000)
+
+        # with our PID (as timedelta)
+        with patch.dict(os.environ, {"WATCHDOG_PID": str(os.getpid()), **test_dict}, clear=True):
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            self.assertEqual(cut.timeout_td, timedelta(microseconds=15000000))
+
+        # bad PID (not ours)
+        # somebody's going to try to test us in a container and get mad when we were PID 1
+        with patch.dict(os.environ, {"WATCHDOG_PID": str(1), **test_dict}, clear=True):
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            self.assertEqual(cut.timeout, 0)
+
+        # worse PID
+        with patch.dict(os.environ, {"WATCHDOG_PID": "not even a number", **test_dict}, clear=True):
+            cut = Notifier(sock=Mock(spec=["sendto"]))
+            self.assertEqual(cut.timeout, 0)
+
+    def test_timeout_due(self):
+        test_dict = {"NOTIFY_SOCKET": self.TEST_ADDR,
+                     "WATCHDOG_USEC": "2000000",  # 2s
+                    }
+        with patch("sd_notify.Notifier._send"):  # Don't do anything on send
+            with patch.dict(os.environ, test_dict, clear=True):
+                cut = Notifier(sock=sentinel.socket)
+                self.assertEqual(cut.timeout, 2000000)
+                self.assertIs(cut.notify_due, True)  # At start, it is "overdue" since never sent
+                cut.notify()
+                self.assertIs(cut.notify_due, False)  # It shouldn't be expecting already
+                sleep(0.7)
+                self.assertIs(cut.notify_due, False)  # Still shouldn't
+                sleep(0.4)
+                self.assertIs(cut.notify_due, True)  # Now it should
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Added sd_watchdog_enabled(3) capabilities:
  * New properties: timeout, timeout_td, notify_due to help you know when you need to report to watchdog
    * "timeout" presents number of microseconds in WATCHDOG_USEC variable as int
    * "timeout_td" presents it as a pythonic datetime.timedelta
    * "notify_due" is boolean flag indicating it has been over half the window since last update

Added example (daemon.py) and more documentation, including systemd service files

Added commands to Makefile: help (default), install, uninstall, test
  * Also ensure wheel package installed

Fixed bug with abstract socket addresses (the "other" Python sdnotify package had that)

Stopped errors on all methods if watchdog not actually enabled
  * Calling code won't need to guard with is_enabled

Made more pythonic "is_enabled" property instead of "enabled()" (kept for legacy)

All new additions added to the self-test suite

Test suite can now be directly called from the command line (or "make test")
